### PR TITLE
feat: add AppStream stock icons for multiflexi and multiflexi-common

### DIFF
--- a/debian/cz.vitexsoftware.multiflexi.metainfo.xml
+++ b/debian/cz.vitexsoftware.multiflexi.metainfo.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="generic">
+  <id>cz.vitexsoftware.multiflexi</id>
+  <icon type="stock">multiflexi</icon>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <name>MultiFlexi</name>
+  <summary>Run various tools on top of AbraFlexi and Stormware Pohoda</summary>
+  <description>
+    <p>
+      Define server, customers and its companies. Then specify which services and commands run upon it.
+    </p>
+  </description>
+  <url type="homepage">https://github.com/VitexSoftware/MultiFlexi</url>
+  <url type="bugtracker">https://github.com/VitexSoftware/MultiFlexi/issues</url>
+  <developer id="cz.vitexsoftware">
+    <name>VitexSoftware</name>
+  </developer>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/debian/multiflexi.install
+++ b/debian/multiflexi.install
@@ -1,0 +1,2 @@
+multiflexi.svg	usr/share/icons/hicolor/scalable/apps/
+debian/cz.vitexsoftware.multiflexi.metainfo.xml	usr/share/metainfo/


### PR DESCRIPTION
## Summary

- Add `debian/cz.vitexsoftware.multiflexi.metainfo.xml` with `<icon type="stock">multiflexi</icon>` for the `multiflexi` package
- Add `debian/multiflexi.install` to install `multiflexi.svg` into `usr/share/icons/hicolor/scalable/apps/` and the metainfo into `usr/share/metainfo/`
- `multiflexi-common` was already correctly configured; no changes needed there

## Test plan

- [ ] Build both packages and verify `multiflexi.svg` lands in `/usr/share/icons/hicolor/scalable/apps/multiflexi.svg`
- [ ] Verify `/usr/share/metainfo/cz.vitexsoftware.multiflexi.metainfo.xml` is installed in the `multiflexi` package
- [ ] Run `appstreamcli validate /usr/share/metainfo/cz.vitexsoftware.multiflexi.metainfo.xml` — expect no errors
- [ ] Confirm `multiflexi-common` still installs its icon and metainfo correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added AppStream metadata to enable proper application discovery in system package managers and application launchers.
  * Configured installation of application icon to system directories for consistent desktop environment integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VitexSoftware/multiflexi-common/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->